### PR TITLE
Add token factory.

### DIFF
--- a/docs/get-it-started.md
+++ b/docs/get-it-started.md
@@ -91,31 +91,16 @@ class PaypalController extends CController
             $paymentName
         );
 
-        $paymentDetails = $storage->createModel();
-        $paymentDetails['PAYMENTREQUEST_0_CURRENCYCODE'] = 'USD';
-        $paymentDetails['PAYMENTREQUEST_0_AMT'] = 1.23;
-        $storage->updateModel($paymentDetails);
+        $details = $storage->createModel();
+        $details['PAYMENTREQUEST_0_CURRENCYCODE'] = 'USD';
+        $details['PAYMENTREQUEST_0_AMT'] = 1.23;
+        $storage->updateModel($details);
+        
+        $captureToken = $payum->getTokenFactory()->createCaptureToken($paymentName, $details, 'paypal/done');
 
-        $doneToken = $tokenStorage->createModel();
-        $doneToken->setPaymentName($paymentName);
-        $doneToken->setDetails($storage->getIdentificator($paymentDetails));
-        $doneToken->setTargetUrl(
-            $this->createAbsoluteUrl('paypal/done', array('payum_token' => $doneToken->getHash()))
-        );
-        $tokenStorage->updateModel($doneToken);
-
-        $captureToken = $tokenStorage->createModel();
-        $captureToken->setPaymentName('paypal');
-        $captureToken->setDetails($storage->getIdentificator($paymentDetails));
-        $captureToken->setTargetUrl(
-            $this->createAbsoluteUrl('payment/capture', array('payum_token' => $captureToken->getHash()))
-        );
-        $captureToken->setAfterUrl($doneToken->getTargetUrl());
-        $tokenStorage->updateModel($captureToken);
-
-        $paymentDetails['RETURNURL'] = $captureToken->getTargetUrl();
-        $paymentDetails['CANCELURL'] = $captureToken->getTargetUrl();
-        $storage->updateModel($paymentDetails);
+        $details['RETURNURL'] = $captureToken->getTargetUrl();
+        $details['CANCELURL'] = $captureToken->getTargetUrl();
+        $storage->updateModel($details);
 
         $this->redirect($captureToken->getTargetUrl());
     }

--- a/src/Payum/YiiExtension/PaymentController.php
+++ b/src/Payum/YiiExtension/PaymentController.php
@@ -1,7 +1,6 @@
 <?php
 namespace Payum\YiiExtension;
 
-use Payum\Core\Request\BinaryMaskStatusRequest;
 use Payum\Core\Request\InteractiveRequestInterface;
 use Payum\Core\Request\Http\RedirectUrlInteractiveRequest;
 use Payum\Core\Request\SecuredCaptureRequest;
@@ -21,15 +20,16 @@ class PaymentController extends \CController
         $token = $this->getPayum()->getHttpRequestVerifier()->verify($_REQUEST);
         $payment = $this->getPayum()->getRegistry()->getPayment($token->getPaymentName());
 
-        $status = new BinaryMaskStatusRequest($token);
-        $payment->execute($status);
-
-        $capture = new SecuredCaptureRequest($token);
-        $payment->execute($capture);
+        $payment->execute($capture = new SecuredCaptureRequest($token));
 
         $this->getPayum()->getHttpRequestVerifier()->invalidate($token);
 
         $this->redirect($token->getAfterUrl());
+    }
+
+    public function actionNotify()
+    {
+        throw new \LogicException('Not Implemented');
     }
 
     public function handleException(\CExceptionEvent $event)

--- a/src/Payum/YiiExtension/PayumComponent.php
+++ b/src/Payum/YiiExtension/PayumComponent.php
@@ -4,6 +4,7 @@ namespace Payum\YiiExtension;
 use Payum\Core\PaymentInterface;
 use Payum\Core\Registry\RegistryInterface;
 use Payum\Core\Registry\SimpleRegistry;
+use Payum\Core\Security\GenericTokenFactoryInterface;
 use Payum\Core\Security\HttpRequestVerifierInterface;
 use Payum\Core\Security\PlainHttpRequestVerifier;
 use Payum\Core\Storage\StorageInterface;
@@ -26,6 +27,11 @@ class PayumComponent extends \CApplicationComponent
     public $tokenStorage;
 
     /**
+     * @var GenericTokenFactoryInterface
+     */
+    public $tokenFactory;
+
+    /**
      * @var HttpRequestVerifierInterface
      */
     protected $httpRequestVerifier;
@@ -40,6 +46,7 @@ class PayumComponent extends \CApplicationComponent
         $this->registry = new SimpleRegistry($this->payments, $this->storages, null);
 
         $this->httpRequestVerifier = new PlainHttpRequestVerifier($this->tokenStorage);
+        $this->tokenFactory = new TokenFactory($this->tokenStorage, $this->registry, 'payment/capture', 'payment/notify');
     }
 
     /**
@@ -48,6 +55,14 @@ class PayumComponent extends \CApplicationComponent
     public function getTokenStorage()
     {
         return $this->tokenStorage;
+    }
+
+    /**
+     * @return GenericTokenFactoryInterface
+     */
+    public function getTokenFactory()
+    {
+        return $this->tokenFactory;
     }
 
     /**

--- a/src/Payum/YiiExtension/TokenFactory.php
+++ b/src/Payum/YiiExtension/TokenFactory.php
@@ -1,0 +1,25 @@
+<?php
+namespace Payum\YiiExtension;
+
+use Payum\Core\Security\AbstractGenericTokenFactory;
+
+class TokenFactory extends AbstractGenericTokenFactory
+{
+
+    /**
+     * @param string $path
+     * @param array $parameters
+     *
+     * @return string
+     */
+    protected function generateUrl($path, array $parameters = array())
+    {
+        $ampersand = '&';
+        $schema = '';
+
+        return
+            \Yii::app()->getRequest()->getHostInfo($schema).
+            \Yii::app()->createUrl(trim($path,'/'),$parameters, $ampersand)
+        ;
+    }
+}


### PR DESCRIPTION
Simplify token creation by using a factory, instead of doing:

``` php
<?php

        $doneToken = $tokenStorage->createModel();
        $doneToken->setPaymentName($paymentName);
        $doneToken->setDetails($storage->getIdentificator($paymentDetails));
        $doneToken->setTargetUrl(
            $this->createAbsoluteUrl('paypal/done', array('payum_token' => $doneToken->getHash()))
        );
        $tokenStorage->updateModel($doneToken);

        $captureToken = $tokenStorage->createModel();
        $captureToken->setPaymentName('paypal');
        $captureToken->setDetails($storage->getIdentificator($paymentDetails));
        $captureToken->setTargetUrl(
            $this->createAbsoluteUrl('payment/capture', array('payum_token' => $captureToken->getHash()))
        );
        $captureToken->setAfterUrl($doneToken->getTargetUrl());
        $tokenStorage->updateModel($captureToken);

        $paymentDetails['RETURNURL'] = $captureToken->getTargetUrl();
        $paymentDetails['CANCELURL'] = $captureToken->getTargetUrl();
        $storage->updateModel($paymentDetails);

```

we just do:

``` php
<?php

$payum->getTokenFactory()->createCaptureToken(
    $paymentName, 
    $paymentDetails, 
    'paypal/done'
);
```

@alexandernst Could you please test it since you have working app?
